### PR TITLE
Fix file list not splitting correctly.

### DIFF
--- a/survivingCodeLinesStat.js
+++ b/survivingCodeLinesStat.js
@@ -61,9 +61,12 @@ function getLinesOfCodeFromRevision(revision, fileFilter) {
 	// restore stdio
 	process.stdio = 'inherit';
 	var fileNames = execSync(`git ls-files ${fileFilter} | xargs`).toString();
-	var files = fileNames.replace('\n', '').split(' ');
+	var files = fileNames.replace(/\n/g, ' ').split(' ');
 
 	files.forEach(file => {
+		if (file === '') {
+			return;
+		}
 		fileCounter++;
 		getLinesOfCodeFromFile(file, lineMap);
 	});


### PR DESCRIPTION
The replace function only replaces the first occurence, but with a regex we can set the global flag to replace all newlines in the string.

Also, replace newlines with a blank space so file paths will be separated. Occasionally this makes array get some empty strings that we can skip in the loop.